### PR TITLE
Don't refer to people as "other things"

### DIFF
--- a/Vision/README.md
+++ b/Vision/README.md
@@ -41,7 +41,7 @@ In our operations and membership, we will:
 *	Provide an open forum, where diverse voices from around the world and industries come together, incubate and build consensus for global standards for Web technologies, including organizations of all sizes (from single-person companies to multi-nationals) and considering public feedback.
 * Encourage incubation in new areas and industries with open platforms for discussion, collaboration and innovation, making it more structured and improving consensus-building among key stake holders.
 * Strive for the broadest participation, along axes including worldwide participation, diversity and inclusion, facilitating balance, equity and cooperation among the participants from different industries, user groups and organizational sizes, and thus establishing W3C as representative of the whole community.
-* Increase involvement of under-represented key stakeholders such as end users, content creators, developers etc.
+* Increase involvement of under-represented key stakeholders such as end users, content creators, developers, and others.
 * Ensure transparency, equity and fairness. Our work will not be exclusively dominated by any person, company or interest group.
 * Establish and improve collaborative relationships with other organizations in the domain of Internet and Web standards, including building and maintaining respected relationships with governments and businesses for providing credible advice.
 


### PR DESCRIPTION
etc. means "and other things", so we need et al., or more likely the english "and others"