### PR TITLE
voluntary standards forum

### DIFF
--- a/Vision/README.md
+++ b/Vision/README.md
@@ -79,7 +79,7 @@ serving the Vision for the Web.
 	openly developed with consensus of industry and key stakeholders.
 
 # Mission of the W3C
-The fundamental purpose of the W3C is to provide an open forum 
+The fundamental purpose of the W3C is to provide an open voluntary standards forum 
 where diverse voices from around the world
 and from different industries
 work together to build consensus


### PR DESCRIPTION
@frivoal suggested to me that we should be explicit, somewhere very upfront that W3C is a *voluntary* standards forum, as opposed to legislated or otherwise compelled. We can expand further later (in the document, in another PR) on to summarize what voluntary means for those who are not familiar, but wanted to start with this small change to acknowledge and explicitly state what is already true, and set expectations accordingly.