### PR TITLE
Writing from a position of greater humility

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -21,7 +21,7 @@ Status Text:
 	The intent is for this document to eventually become a <a href="https://www.w3.org/2023/Process-20230612/#w3c-statement">W3C Statement</a>.
 
 Boilerplate: omit conformance
-Markup Shorthands: markdown yes 
+Markup Shorthands: markdown yes
 </pre>
 
 # Purpose of this Document # {#purpose}
@@ -44,9 +44,9 @@ Markup Shorthands: markdown yes
 
 # The Mission of W3C # {#mission}
 
-	W3C leads the community 
-	in defining a World Wide Web that puts users first, 
-	by developing technical standards and guidelines 
+	W3C convenes the community
+	in defining a World Wide Web that puts users first,
+	by developing technical standards and guidelines
 	to empower an equitable, informed, and interconnected society.
 
 # Introduction # {#intro}
@@ -54,7 +54,7 @@ Markup Shorthands: markdown yes
 	The World Wide Web was originally conceived
 	as a tool for sharing information.
 	It has evolved rapidly into a fundamental part of humanity,
-	sparking major social change by 
+	sparking major social change by
 	providing and expanding access to knowledge, education,
 	commerce and shopping, social experiences,
 	civic functions, entertainment, and more.
@@ -76,20 +76,20 @@ Markup Shorthands: markdown yes
 
 	Technology is not neutral;
 	new technologies enable new actions and new possibilities, and
-	we must take responsibility 
+	we must take responsibility
 	to address the actual impact of our work.
-	The W3C’s Technical Architecture Group's work 
-	to clearly define <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">Ethical Web Principles</a> is a strong basis 
-	to improve the ethical integrity of the Web. 
+	The W3C’s Technical Architecture Group's work
+	to clearly define <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">Ethical Web Principles</a> is a strong basis
+	to improve the ethical integrity of the Web.
 
-	The Web has had a tremendous impact on the world, 
-	and its impact will continue to grow in the future, 
+	The Web has had a tremendous impact on the world,
+	and its impact will continue to grow in the future,
 	as it expands reach, knowledge, education, and services even more broadly.
-	We believe the World Wide Web should be 
-	inclusive and respectful of its users: 
-	a Web that supports facts over falsehoods, 
-	people over profits, 
-	humanity over hate. 
+	We believe the World Wide Web should be
+	inclusive and respectful of its users:
+	a Web that supports facts over falsehoods,
+	people over profits,
+	humanity over hate.
 
 # W3C's Vision for the World Wide Web # {#vision-web}
 
@@ -100,23 +100,23 @@ Markup Shorthands: markdown yes
 
 # Vision for W3C # {#vision-org}
 
-	The World Wide Web Consortium (W3C) was founded as an organization 
-	to provide a consistent architecture 
-	across the rapid pace of progress in the Web, 
-	and to build a common community to support its development. 
-	It has become an association where diverse voices from around the world 
+	The World Wide Web Consortium (W3C) was founded as an organization
+	to provide a consistent architecture
+	across the rapid pace of progress in the Web,
+	and to build a common community to support its development.
+	It has become an association where diverse voices from around the world
 	and from different industries and organizations work together to evolve the Web.
 
-	To build a better future, the W3C must rise even further 
-	to the challenge of improving the Web's fundamental integrity, 
-	while continuing to expand the Web’s scope and reach. 
+	To build a better future, the W3C must rise even further
+	to the challenge of improving the Web's fundamental integrity,
+	while continuing to expand the Web’s scope and reach.
 	The Operational Principles for the W3C should reflect the core values of the Web itself.
 
-	These core values will be clearly demonstrated by how W3C leads the Web forward: 
-	by being inclusive, principled, and continually striving to make the Web better 
+	These core values will be clearly demonstrated by how W3C leads the Web forward:
+	by being inclusive, principled, and continually striving to make the Web better
 	through these principles and the Ethical Web Principles.
 	This will lead to a Web that is more equitable,
-	better serving its users in connecting the world. 
+	better serving its users in connecting the world.
 	As the Ethical Web Principles state, “The web should empower an equitable, informed and interconnected society.”
 
 # Operational Principles for W3C # {#op-principles}
@@ -129,9 +129,9 @@ Markup Shorthands: markdown yes
 	In order to fulfill this function, we will follow these operational principles:
 
 	* **User-first**: We put the needs of users first:
-		above authors, publishers, implementers, paying W3C Members, or theoretical purity.	
-	* **Multi-stakeholder**: We intentionally involve stakeholders from end to end 
-		in building the Web: developers, content creators, and end users. 
+		above authors, publishers, implementers, paying W3C Members, or theoretical purity.
+	* **Multi-stakeholder**: We intentionally involve stakeholders from end to end
+		in building the Web: developers, content creators, and end users.
 		Our work will not be dominated by any person, company, or interest group.
 	* **Diversity**: We believe in diversity
 		and inclusion of participants from different
@@ -143,11 +143,11 @@ Markup Shorthands: markdown yes
 		industries,
 		organizational sizes,
 		and more.
-		In order to ensure the W3C serves the needs of the entire Web user base, 
+		In order to ensure the W3C serves the needs of the entire Web user base,
 		we also strive to broaden diversity and inclusion for our own participants.
-	* **Consistent Review**: 
-		We will ensure the technical standards of the Web meet broad goals 
-		using consistent horizontal review to ensure accessibility, 
+	* **Consistent Review**:
+		We will ensure the technical standards of the Web meet broad goals
+		using consistent horizontal review to ensure accessibility,
 		internationalization,
 		sustainability,
 		privacy,
@@ -159,14 +159,14 @@ Markup Shorthands: markdown yes
 	* **Open Participation**: We welcome individuals and organizations of all sizes
 		(from single-person companies to multi-nationals),
 		and take feedback from the general public.
-	* **Interoperability**: We believe proven interoperable implementation is a 
-		requirement for broad adoption of standards. 
-		To ensure reliable interoperability, 
-		we require multiple implementations 
+	* **Interoperability**: We believe proven interoperable implementation is a
+		requirement for broad adoption of standards.
+		To ensure reliable interoperability,
+		we require multiple implementations
 		and open test suites for our standards.
-	* **Incubation**: The Web will continue to expand 
-		in user base, global reach, and technical breadth. 
-		We are committed to encouraging incubation in new areas, 
+	* **Incubation**: The Web will continue to expand
+		in user base, global reach, and technical breadth.
+		We are committed to encouraging incubation in new areas,
 		collaborating on innovations across our community.
 	* **Avoid Centralization**: We aim to reduce centralization in Web architecture,
 		minimizing single points of failure

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -71,10 +71,7 @@ Markup Shorthands: markdown yes
 	and its impact will continue to grow in the future,
 	as it expands reach, knowledge, education, and services even more broadly.
 	We believe the World Wide Web should be
-	inclusive and respectful of its users:
-	a Web that supports facts over falsehoods,
-	people over profits,
-	humanity over hate.
+	inclusive and respectful of its users.
 
 # W3C's Vision for the World Wide Web # {#vision-web}
 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -59,21 +59,6 @@ Markup Shorthands: markdown yes
 	commerce and shopping, social experiences,
 	civic functions, entertainment, and more.
 
-	The Web's amazing success
-	has also led to many unintended and undesirable consequences
-	that harm society:
-	openness and anonymity have given rise to scams, phishing, and fraud;
-	the ease of gathering personal information has led to business models
-	that mine and sell detailed user data,
-	without people's awareness or consent;
-	rapid global information sharing
-	has allowed misinformation to flourish and be exploited
-	for political or commercial gain.
-	This has divided societies and incited hate.
-	We must do better.
-	We must take steps to address these consequences
-	in the standards we create.
-
 	Technology is not neutral;
 	new technologies enable new actions and new possibilities, and
 	we must take responsibility

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -120,7 +120,7 @@ Markup Shorthands: markdown yes
 		and more.
 		In order to ensure the W3C serves the needs of the entire Web user base, 
 		we also strive to broaden diversity and inclusion for our own participants.
-	* **Consistent Review**:
+	* **Consistent Review**: 
 		We will ensure the technical standards of the Web meet broad goals 
 		using consistent horizontal review to ensure accessibility, 
 		internationalization,
@@ -149,7 +149,7 @@ Markup Shorthands: markdown yes
 	* **Collaboration**: We are committed to establishing and improving collaborative relationships
 		with other Internet and Web standards organizations,
 		and building and maintaining respected relationships
-		with governments and businesses for providing credible advice. 
+		with governments and businesses for providing credible advice.
 
 # Acknowledgements and supporting material # {#acknowledgements}
 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -21,7 +21,7 @@ Status Text:
 	The intent is for this document to eventually become a <a href="https://www.w3.org/2023/Process-20230612/#w3c-statement">W3C Statement</a>.
 
 Boilerplate: omit conformance
-Markup Shorthands: markdown yes
+Markup Shorthands: markdown yes 
 </pre>
 
 # Purpose of this Document # {#purpose}
@@ -44,9 +44,9 @@ Markup Shorthands: markdown yes
 
 # The Mission of W3C # {#mission}
 
-	W3C convenes the community
-	in defining a World Wide Web that puts users first,
-	by developing technical standards and guidelines
+	W3C convenes the community 
+	in defining a World Wide Web that puts users first, 
+	by developing technical standards and guidelines 
 	to empower an equitable, informed, and interconnected society.
 
 # Introduction # {#intro}
@@ -54,44 +54,44 @@ Markup Shorthands: markdown yes
 	The World Wide Web was originally conceived
 	as a tool for sharing information.
 	It has evolved rapidly into a fundamental part of humanity,
-	sparking major social change by
+	sparking major social change by 
 	providing and expanding access to knowledge, education,
 	commerce and shopping, social experiences,
 	civic functions, entertainment, and more.
 
 	Technology is not neutral;
 	new technologies enable new actions and new possibilities, and
-	we must take responsibility
+	we must take responsibility 
 	to address the actual impact of our work.
-	The W3C’s Technical Architecture Group's work
-	to clearly define <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">Ethical Web Principles</a> is a strong basis
-	to improve the ethical integrity of the Web.
+	The W3C’s Technical Architecture Group's work 
+	to clearly define <a href="https://www.w3.org/2001/tag/doc/ethical-web-principles/">Ethical Web Principles</a> is a strong basis 
+	to improve the ethical integrity of the Web. 
 
-	The Web has had a tremendous impact on the world,
-	and its impact will continue to grow in the future,
+	The Web has had a tremendous impact on the world, 
+	and its impact will continue to grow in the future, 
 	as it expands reach, knowledge, education, and services even more broadly.
 	We believe the World Wide Web should be
 	inclusive and respectful of its users.
 
 # Vision for W3C # {#vision-org}
 
-	The World Wide Web Consortium (W3C) was founded as an organization
-	to provide a consistent architecture
-	across the rapid pace of progress in the Web,
-	and to build a common community to support its development.
-	It has become an association where diverse voices from around the world
+	The World Wide Web Consortium (W3C) was founded as an organization 
+	to provide a consistent architecture 
+	across the rapid pace of progress in the Web, 
+	and to build a common community to support its development. 
+	It has become an association where diverse voices from around the world 
 	and from different industries and organizations work together to evolve the Web.
 
-	To build a better future, the W3C must rise even further
-	to the challenge of improving the Web's fundamental integrity,
-	while continuing to expand the Web’s scope and reach.
+	To build a better future, the W3C must rise even further 
+	to the challenge of improving the Web's fundamental integrity, 
+	while continuing to expand the Web’s scope and reach. 
 	The Operational Principles for the W3C should reflect the core values of the Web itself.
 
-	These core values will be clearly demonstrated by how W3C leads the Web forward:
-	by being inclusive, principled, and continually striving to make the Web better
+	These core values will be clearly demonstrated by how W3C leads the Web forward: 
+	by being inclusive, principled, and continually striving to make the Web better 
 	through these principles and the Ethical Web Principles.
 	This will lead to a Web that is more equitable,
-	better serving its users in connecting the world.
+	better serving its users in connecting the world. 
 	As the Ethical Web Principles state, “The web should empower an equitable, informed and interconnected society.”
 
 # Operational Principles for W3C # {#op-principles}
@@ -104,9 +104,9 @@ Markup Shorthands: markdown yes
 	In order to fulfill this function, we will follow these operational principles:
 
 	* **User-first**: We put the needs of users first:
-		above authors, publishers, implementers, paying W3C Members, or theoretical purity.
-	* **Multi-stakeholder**: We intentionally involve stakeholders from end to end
-		in building the Web: developers, content creators, and end users.
+		above authors, publishers, implementers, paying W3C Members, or theoretical purity.	
+	* **Multi-stakeholder**: We intentionally involve stakeholders from end to end 
+		in building the Web: developers, content creators, and end users. 
 		Our work will not be dominated by any person, company, or interest group.
 	* **Diversity**: We believe in diversity
 		and inclusion of participants from different
@@ -118,11 +118,11 @@ Markup Shorthands: markdown yes
 		industries,
 		organizational sizes,
 		and more.
-		In order to ensure the W3C serves the needs of the entire Web user base,
+		In order to ensure the W3C serves the needs of the entire Web user base, 
 		we also strive to broaden diversity and inclusion for our own participants.
 	* **Consistent Review**:
-		We will ensure the technical standards of the Web meet broad goals
-		using consistent horizontal review to ensure accessibility,
+		We will ensure the technical standards of the Web meet broad goals 
+		using consistent horizontal review to ensure accessibility, 
 		internationalization,
 		sustainability,
 		privacy,
@@ -134,14 +134,14 @@ Markup Shorthands: markdown yes
 	* **Open Participation**: We welcome individuals and organizations of all sizes
 		(from single-person companies to multi-nationals),
 		and take feedback from the general public.
-	* **Interoperability**: We believe proven interoperable implementation is a
-		requirement for broad adoption of standards.
-		To ensure reliable interoperability,
-		we require multiple implementations
+	* **Interoperability**: We believe proven interoperable implementation is a 
+		requirement for broad adoption of standards. 
+		To ensure reliable interoperability, 
+		we require multiple implementations 
 		and open test suites for our standards.
-	* **Incubation**: The Web will continue to expand
-		in user base, global reach, and technical breadth.
-		We are committed to encouraging incubation in new areas,
+	* **Incubation**: The Web will continue to expand 
+		in user base, global reach, and technical breadth. 
+		We are committed to encouraging incubation in new areas, 
 		collaborating on innovations across our community.
 	* **Avoid Centralization**: We aim to reduce centralization in Web architecture,
 		minimizing single points of failure
@@ -149,7 +149,7 @@ Markup Shorthands: markdown yes
 	* **Collaboration**: We are committed to establishing and improving collaborative relationships
 		with other Internet and Web standards organizations,
 		and building and maintaining respected relationships
-		with governments and businesses for providing credible advice.
+		with governments and businesses for providing credible advice. 
 
 # Acknowledgements and supporting material # {#acknowledgements}
 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -73,13 +73,6 @@ Markup Shorthands: markdown yes
 	We believe the World Wide Web should be
 	inclusive and respectful of its users.
 
-# W3C's Vision for the World Wide Web # {#vision-web}
-
-	* The Web is for <a href="https://www.w3.org/TR/ethical-web-principles/#allpeople">all humanity</a>.
-	* The Web is designed for the <a href="https://www.w3.org/TR/ethical-web-principles/#noharm">good of its users</a>.
-	* The Web must be <a href="https://www.w3.org/TR/ethical-web-principles/#privacy">safe for its users</a>.
-	* There is <a href="https://www.w3.org/TR/ethical-web-principles/#oneweb">one interoperable world-wide Web</a>.
-
 # Vision for W3C # {#vision-org}
 
 	The World Wide Web Consortium (W3C) was founded as an organization


### PR DESCRIPTION
This PR introduces several changes that support the document in speaking from a position of greater humility. This takes several forms:

- We don't lead, we convene.
- We don't make statements that we haven't done the homework to support. The "Web's amazing success" paragraph has a number of statements that connect various things (e.g. anonymity to fraud, information sharing with misinformation) as bold statements of fact that don't seem grounded in scholarship. We should either stick to what we have a clear claim to expertise on or build atop the work of others (as opposed to relying on "well-meaning technical person common sense").
- The "We believe the WWW" part has soundbites that feel self-congratulatory, may be cheap talk that seems hard to operationalise, or are flat out dangerous (e.g. "facts over falsehood"). We shouldn't promise things that we don't know how to deliver or commit to stances that run counter to Web values.
- The vision-web section is an arbitrary subset of the EWP. If the subset is meaningful, we should ask the TAG to reflect that in its document, perhaps by giving some prominence to those four principles picked from their twelve. If it isn't, we should respect their work and not make the subset.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darobin/AB-public/pull/134.html" title="Last updated on Oct 24, 2023, 5:30 PM UTC (0ec2943)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/134/7a31b36...darobin:0ec2943.html" title="Last updated on Oct 24, 2023, 5:30 PM UTC (0ec2943)">Diff</a>