### PR TITLE
Capture what we do, not just how we do it, in the Vision for W3C #119 #118

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -106,18 +106,17 @@ Markup Shorthands: markdown yes
 	and to build a common community to support its development. 
 	It has become an association where diverse voices from around the world 
 	and from different industries and organizations work together to evolve the Web.
-
 	To build a better future, the W3C must rise even further 
 	to the challenge of improving the Web's fundamental integrity, 
 	while continuing to expand the Web’s scope and reach. 
-	The Operational Principles for the W3C should reflect the core values of the Web itself.
 
-	These core values will be clearly demonstrated by how W3C leads the Web forward: 
-	by being inclusive, principled, and continually striving to make the Web better 
-	through these principles and the Ethical Web Principles.
-	This will lead to a Web that is more equitable,
-	better serving its users in connecting the world. 
-	As the Ethical Web Principles state, “The web should empower an equitable, informed and interconnected society.”
+	As W3C leads the Web forward,
+	our mission is to embody our fundamental values and principles
+	in the architecture of the Web.
+	As the Ethical Web Principles state,
+	“The web should empower an equitable, informed, and interconnected society.”
+	Likewise, our Operational Principles for W3C
+	reflect the core values of the Web itself.
 
 # Operational Principles for W3C # {#op-principles}
 


### PR DESCRIPTION
Tries to address #118 (restore sentence about embodying our values into the Web's architecture) and #119 (demonstrating our values through our output, not just our operations). Also tries to reduce a little bit the redundancies and awkward sentence transitions in this section. I'm not sure it succeeds as much as I'd like in that direction though, so marking it as a draft for input. :)