### PR TITLE
Add anchors for each entry in the Operational Principles section

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -128,12 +128,16 @@ Markup Shorthands: markdown yes
 	on voluntary global standards for Web technologies.
 	In order to fulfill this function, we will follow these operational principles:
 
-	* **User-first**: We put the needs of users first:
+	<ul>
+	<li id=user-first>
+		**User-first**: We put the needs of users first:
 		above authors, publishers, implementers, paying W3C Members, or theoretical purity.	
-	* **Multi-stakeholder**: We intentionally involve stakeholders from end to end 
+	<li id=multi-stakeholder>
+		**Multi-stakeholder**: We intentionally involve stakeholders from end to end
 		in building the Web: developers, content creators, and end users. 
 		Our work will not be dominated by any person, company, or interest group.
-	* **Diversity**: We believe in diversity
+	<li id=diversity>
+		**Diversity**: We believe in diversity
 		and inclusion of participants from different
 		geographical locations,
 		cultures,
@@ -145,36 +149,45 @@ Markup Shorthands: markdown yes
 		and more.
 		In order to ensure the W3C serves the needs of the entire Web user base, 
 		we also strive to broaden diversity and inclusion for our own participants.
-	* **Consistent Review**: 
+	<li id=review>
+		**Consistent Review**:
 		We will ensure the technical standards of the Web meet broad goals 
 		using consistent horizontal review to ensure accessibility, 
 		internationalization,
 		sustainability,
 		privacy,
 		and security.
-	* **Consensus**: We believe in principled, community-wide consensus-building
+	<li id=consensus>
+		**Consensus**: We believe in principled, community-wide consensus-building
 		as the basis for building standards.
-	* **Free to Implement**: Our standards are rooted in a strong royalty-free patent policy
+	<li id=free-impl>
+		**Free to Implement**: Our standards are rooted in a strong royalty-free patent policy
 		and open copyright licenses.
-	* **Open Participation**: We welcome individuals and organizations of all sizes
+	<li id=open>
+		**Open Participation**: We welcome individuals and organizations of all sizes
 		(from single-person companies to multi-nationals),
 		and take feedback from the general public.
-	* **Interoperability**: We believe proven interoperable implementation is a 
+	<li id=interop>
+		**Interoperability**: We believe proven interoperable implementation is a
 		requirement for broad adoption of standards. 
 		To ensure reliable interoperability, 
 		we require multiple implementations 
 		and open test suites for our standards.
-	* **Incubation**: The Web will continue to expand 
+	<li id=incub>
+		**Incubation**: The Web will continue to expand
 		in user base, global reach, and technical breadth. 
 		We are committed to encouraging incubation in new areas, 
 		collaborating on innovations across our community.
-	* **Avoid Centralization**: We aim to reduce centralization in Web architecture,
+	<li id=avoid-central>
+		**Avoid Centralization**: We aim to reduce centralization in Web architecture,
 		minimizing single points of failure
 		and single points of control.
-	* **Collaboration**: We are committed to establishing and improving collaborative relationships
+	<li id=collab>
+		**Collaboration**: We are committed to establishing and improving collaborative relationships
 		with other Internet and Web standards organizations,
 		and building and maintaining respected relationships
 		with governments and businesses for providing credible advice.
+	</ul>
 
 # Acknowledgements and supporting material # {#acknowledgements}
 


### PR DESCRIPTION
As welcome by the Editor in https://github.com/w3c/AB-public/issues/139#issuecomment-1781550838

Closes #139 if merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/AB-public/pull/142.html" title="Last updated on Oct 27, 2023, 10:21 AM UTC (6c2e74e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/142/61d12dc...frivoal:6c2e74e.html" title="Last updated on Oct 27, 2023, 10:21 AM UTC (6c2e74e)">Diff</a>