### PR TITLE
editorial: rm awkward dupe wording, +ed

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -8,6 +8,7 @@ TR: https://www.w3.org/TR/w3c-vision/
 ED: https://w3c.github.io/AB-public/Vision
 Previous Version: https://www.w3.org/TR/2023/DNOTE-w3c-vision-20231026/
 Editor: Chris Wilson, Google, w3cid 3742
+Editor: Tantek Çelik, Mozilla, w3cid 1464
 Abstract:
 	This Vision attempts to help the world understand
 	what W3C is, what it does and why that matters;
@@ -114,7 +115,7 @@ Markup Shorthands: markdown yes
 	to the challenge of improving the Web's fundamental integrity, 
 	while continuing to expand the Web’s scope and reach. 
 
-	The W3C will embed its core values and principles in the Web's architecture as we lead the Web forward.
+	The W3C will embed its core values and principles in the Web's architecture.
 	As the Ethical Web Principles state, “The web should empower an equitable, informed and interconnected society.”
 
 # Operational Principles for W3C # {#op-principles}


### PR DESCRIPTION
removed awkward phrase on the end of a sentence that’s a duplicate of "lead" wording already in the briefer Mission statement add self as co-editor


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/155.html" title="Last updated on Mar 20, 2024, 11:26 PM UTC (326e258)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/155/434fe71...326e258.html" title="Last updated on Mar 20, 2024, 11:26 PM UTC (326e258)">Diff</a>