### PR TITLE
editorial: consistent abstract & purpose use of "articulates"

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -10,9 +10,9 @@ Previous Version: https://www.w3.org/TR/2023/DNOTE-w3c-vision-20231026/
 Editor: Chris Wilson, Google, w3cid 3742
 Editor: Tantek Çelik, Mozilla, w3cid 1464
 Abstract:
-	The W3C Vision states W3C’s mission, 
-	what W3C is, what it does and why that matters;
-	and articulates the values and principles by which it operates
+	The W3C Vision articulates W3C’s mission, 
+	what W3C is, what it does and why that matters,
+	and the values and principles by which it operates
 	and makes decisions.
 
 Status Text:


### PR DESCRIPTION
Change the abstract to use "articulates" instead of "states" consistent with the longer and more explicit Purpose section, and grammar & punctuation edits to make that work.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/160.html" title="Last updated on Mar 27, 2024, 7:08 PM UTC (5a3e0b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/160/cfb9258...5a3e0b3.html" title="Last updated on Mar 27, 2024, 7:08 PM UTC (5a3e0b3)">Diff</a>