### PR TITLE
Mission editorial refactor

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -42,8 +42,6 @@ Markup Shorthands: markdown yes
 		particularly on controversial issues
 	* Be timeless enough to guide W3C yet flexible enough to evolve when needed
 
-# The Mission of W3C # {#mission}
-
 # Introduction # {#intro}
 
 	The World Wide Web was originally conceived

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -44,11 +44,6 @@ Markup Shorthands: markdown yes
 
 # The Mission of W3C # {#mission}
 
-	W3C leads the community 
-	in defining a World Wide Web that puts users first, 
-	by developing technical standards and guidelines 
-	to empower an equitable, informed, and interconnected society.
-
 # Introduction # {#intro}
 
 	The World Wide Web was originally conceived
@@ -58,6 +53,11 @@ Markup Shorthands: markdown yes
 	providing and expanding access to knowledge, education,
 	commerce and shopping, social experiences,
 	civic functions, entertainment, and more.
+
+	The World Wide Web Consortium (W3C) was founded as an organization 
+	to provide a consistent architecture 
+	across the rapid pace of progress in the Web, 
+	and to build a common community to support its development. 
 
 	The Web's amazing success
 	has also led to many unintended and undesirable consequences
@@ -100,10 +100,10 @@ Markup Shorthands: markdown yes
 
 # Vision for W3C # {#vision-org}
 
-	The World Wide Web Consortium (W3C) was founded as an organization 
-	to provide a consistent architecture 
-	across the rapid pace of progress in the Web, 
-	and to build a common community to support its development. 
+	W3C leads the community 
+	in defining a World Wide Web that puts users first, 
+	by developing technical standards and guidelines 
+	to empower an equitable, informed, and interconnected society.
 
 	The fundamental function of W3C today is to provide an open forum
 	where diverse voices from around the world


### PR DESCRIPTION
This PR fixes #161 ; it keeps all content text, but moves the brief elevator pitch to the beginning of the Vision for W3C section, and moves one paragraph from there to the introduction (putting all the "history" together in one place, more clearly identifying what is looking forward and what is looking back).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/162.html" title="Last updated on Mar 27, 2024, 8:22 PM UTC (5b10c14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/162/f27e8dd...5b10c14.html" title="Last updated on Mar 27, 2024, 8:22 PM UTC (5b10c14)">Diff</a>