### PR TITLE
Split diverse perspectives and inclusion points

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -142,11 +142,12 @@ Markup Shorthands: markdown yes
 	<li id=diversity>
 		**Diversity of Perspective**: We believe in seeking diversity
 		of perspectives from different
+		backgrounds,
 		geographical locales,
 		industries,
 		organizational sizes,
 		and more.
-		This serves to ensure W3C serves the needs of the entire Web user base.
+		This ensures W3C serves the needs of the entire Web user base.
 	<li id=review>
 		**Thorough Review**:
 		We ensure the technical standards of the Web use broad and 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -131,14 +131,14 @@ Markup Shorthands: markdown yes
 	<li id=inclusion>
 		**Inclusion**: We believe in actively including
 		and providing a welcoming environment for
-		participants from different
+		participants of different
 		cultures,
-		speaking different languages,
-		with different disabilities,
+		languages,
+		disabilities,
 		gender identities,
 		and more.
 		In order to ensure W3C reflects the entire Web user base, 
-		we will actively seek to be welcoming to all.
+		we will actively seek to be inclusive to all.
 	<li id=diversity>
 		**Diversity of Perspective**: We believe in seeking diversity
 		of perspectives from different

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -128,19 +128,25 @@ Markup Shorthands: markdown yes
 		**Multi-stakeholder**: We intentionally involve stakeholders from end to end
 		in building the Web: developers, content creators, and end users. 
 		Our work will not be dominated by any person, company, or interest group.
-	<li id=diversity>
-		**Diversity**: We believe in diversity
-		and inclusion of participants from different
-		geographical locations,
+	<li id=inclusion>
+		**Inclusion**: We believe in actively including
+		and providing a welcoming environment for
+		participants from different
 		cultures,
-		languages,
-		disabilities,
+		speaking different languages,
+		with different disabilities,
 		gender identities,
+		and more.
+		In order to ensure W3C reflects the entire Web user base, 
+		we will actively seek to be welcoming to all.
+	<li id=diversity>
+		**Diversity of Perspective**: We believe in seeking diversity
+		of perspectives from different
+		geographical locales,
 		industries,
 		organizational sizes,
 		and more.
-		In order to ensure W3C serves the needs of the entire Web user base, 
-		we also strive to broaden diversity and inclusion for our own participants.
+		This serves to ensure W3C serves the needs of the entire Web user base.
 	<li id=review>
 		**Thorough Review**:
 		We ensure the technical standards of the Web use broad and 


### PR DESCRIPTION
An attempt to address #169:  split out diversity and inclusion to address separately.  There is clear overlap, of course, which is why both lists are open-ended.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/171.html" title="Last updated on Apr 12, 2024, 4:41 AM UTC (7a03fa6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/171/aa93157...7a03fa6.html" title="Last updated on Apr 12, 2024, 4:41 AM UTC (7a03fa6)">Diff</a>