### PR TITLE
Give a sensical reading for "Be timeless enough" #167

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -38,9 +38,10 @@ Markup Shorthands: markdown yes
 
 	* Help the world understand what W3C is, what it does, and why it matters
 	* Communicate shared values and principles of the W3C community
-	* Be opinionated enough to provide a framework for making decisions,
+	* Be opinionated enough to provide guidance and a framework for making decisions,
 		particularly on controversial issues
-	* Be timeless enough to guide W3C yet flexible enough to evolve when needed
+	* Be timeless enough to remain relevant without needing frequent revision,
+		while being open to evolving based on the needs of the community
 
 # Introduction # {#intro}
 


### PR DESCRIPTION
Addresses the second point in #167:

> ```
> - * Be timeless enough that it does not need frequent revision.
> + * Be timeless enough to guide W3C yet flexible enough to evolve when needed.
> ```
> 
> I don't think I agree with this edit. The resulting text is a non-sequitur... Timelessness isn't a requirement to guidance, and doesn't create flexibility to evolve either... It's nice to be timeless, and it's nice to be flexible to evolve, but this new sentence as a whole doesn't make sense.

By replacing with

> Be timeless enough to remain relevant without needing frequent revision

which is closer to the original version. Open to other ideas; just don't think the current text particularly makes sense or reflects the original meaning of this bullet point (which was about timelessness meaning it can endure without revision without becoming stale).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/AB-public/pull/181.html" title="Last updated on Oct 9, 2024, 3:03 AM UTC (484a1ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/181/088f4f7...fantasai:484a1ed.html" title="Last updated on Oct 9, 2024, 3:03 AM UTC (484a1ed)">Diff</a>