### PR TITLE
editorial: copy a SOTD consensus line from EWP

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -19,6 +19,7 @@ Status Text:
 	This document was developed by the Advisory Board
 	in cooperation with its <a href="https://www.w3.org/wiki/AB/VisionTF">Vision Task Force</a>.
 	The intent is for this document to eventually become a <a href="https://www.w3.org/2023/Process-20230612/#w3c-statement">W3C Statement</a>.
+	This document reflects the consensus of the AB at the time of publication. 
 	It will continue to evolve, and the AB will issue updates as often as needed.
 
 Boilerplate: omit conformance

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -17,9 +17,9 @@ Abstract:
 
 Status Text:
 	This document was developed by the Advisory Board
-	in cooperation with its <a href="https://www.w3.org/wiki/AB/VisionTF">Vision Task Force</a>.
+	in cooperation with its <a href="https://www.w3.org/wiki/AB/VisionTF">Vision Task Force</a>,
+	and reflects the consensus of the AB at the time of publication. 
 	The intent is for this document to eventually become a <a href="https://www.w3.org/2023/Process-20230612/#w3c-statement">W3C Statement</a>.
-	This document reflects the consensus of the AB at the time of publication. 
 	It will continue to evolve, and the AB will issue updates as often as needed.
 
 Boilerplate: omit conformance


### PR DESCRIPTION
add consensus of the AB in preparation for Note publication, similar to EWP SOTD, in the same place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/186.html" title="Last updated on Oct 3, 2024, 4:26 AM UTC (f38d794)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/186/e9cb601...f38d794.html" title="Last updated on Oct 3, 2024, 4:26 AM UTC (f38d794)">Diff</a>