### PR TITLE
Add ages and economic backgrounds

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -130,6 +130,8 @@ Markup Shorthands: markdown yes
 	<li id=diversity>
 		**Diversity**: We believe in diversity
 		and inclusion of participants from different
+		ages,	
+		economic backgrounds,
 		geographical locations,
 		cultures,
 		languages,


### PR DESCRIPTION
Add ages and economic backgrounds to Vision.bs from https://github.com/w3c/AB-public/pull/185 to include young and old are included in addition to economic status where perspectives can be missed from being in high school or college or being poor/in poverty.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/celestaria/AB-public/pull/190.html" title="Last updated on Oct 3, 2024, 4:45 AM UTC (48bbc7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/190/e9cb601...celestaria:48bbc7a.html" title="Last updated on Oct 3, 2024, 4:45 AM UTC (48bbc7a)">Diff</a>