### PR TITLE
abbr around first use of "W3C" next to expansion

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -52,7 +52,7 @@ Markup Shorthands: markdown yes
 	commerce and shopping, social experiences,
 	civic functions, entertainment, and more.
 
-	The World Wide Web Consortium (W3C) was founded as an organization 
+	The World Wide Web Consortium (<abbr>W3C</abbr>) was founded as an organization 
 	to provide a consistent architecture 
 	across the rapid pace of progress in the Web, 
 	and to build a common community to support its development. 


### PR DESCRIPTION
markup "W3C" as an abbr adjacent to the first use of its expansion


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/191.html" title="Last updated on Oct 3, 2024, 4:33 AM UTC (dd58428)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/191/e9cb601...dd58428.html" title="Last updated on Oct 3, 2024, 4:33 AM UTC (dd58428)">Diff</a>