### PR TITLE
Changes section: adjust diffs link text

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -200,7 +200,7 @@ Markup Shorthands: markdown yes
 
 <h2 id="changes">Changes</h2>
 <h3 id="changes-from-2024-04-03">Changes from <a href="https://www.w3.org/TR/2024/NOTE-w3c-vision-20240403/">2024-04-03 Note</a></h2>
-View <a href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2Fw3c-vision%2F&doc2=https%3A%2F%2Fw3c.github.io%2FAB-public%2FVision">differences between Editor’s Draft and First Public Group Note</a>
+View <a href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2Fw3c-vision%2F&doc2=https%3A%2F%2Fw3c.github.io%2FAB-public%2FVision">all differences from First Public Group Note</a>
 <ul>
 <li>Status of this document: <ul>
   <li>add “and reflects the consensus of the AB at the time of publication”


### PR DESCRIPTION
Make diffs link text more generic, leaving only the diffs link URL needing updating (to the expected updated Note URL) before we publish the updated Note


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 17, 2024, 12:55 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL]([object Object])

```
Error running preprocessor, returned code: 2.
FATAL ERROR: PROGRAMMING ERROR: Group 'W3C/AB' has type 'none', but none of the W3C Statuses are associated with that type.
Your document appears to use tabs to indent, but line 206 starts with spaces.
Your document appears to use tabs to indent, but line 207 starts with spaces.
Your document appears to use tabs to indent, but line 208 starts with spaces.
Your document appears to use tabs to indent, but line 209 starts with spaces.
Your document appears to use tabs to indent, but line 211 starts with spaces.
Your document appears to use tabs to indent, but line 212 starts with spaces.
Your document appears to use tabs to indent, but line 213 starts with spaces.
Your document appears to use tabs to indent, but line 214 starts with spaces.
Your document appears to use tabs to indent, but line 216 starts with spaces.
Your document appears to use tabs to indent, but line 217 starts with spaces.
Your document appears to use tabs to indent, but line 219 starts with spaces.
Your document appears to use tabs to indent, but line 220 starts with spaces.
Your document appears to use tabs to indent, but line 221 starts with spaces.
Your document appears to use tabs to indent, but line 222 starts with spaces.
Your document appears to use tabs to indent, but line 223 starts with spaces.
Your document appears to use tabs to indent, but line 225 starts with spaces.
Your document appears to use tabs to indent, but line 226 starts with spaces.
Your document appears to use tabs to indent, but line 228 starts with spaces.
Your document appears to use tabs to indent, but line 229 starts with spaces.
 ✘  Did not generate, due to errors exceeding the allowed error level.
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/AB-public%23199.)._
</details>
