### PR TITLE
add p id="w3c-state" as demanded by w3.org/pubrules

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -25,7 +25,7 @@ Status Text:
 Boilerplate: omit conformance
 Markup Shorthands: markdown yes 
 </pre>
-
+<p id="w3c-state" style="display:none">W3C Note 18 October 2024</p>
 # Purpose of this Document # {#purpose}
 
 	This document articulates


### PR DESCRIPTION
From Pubrules check:
> Pubrules is having a hard time identifying the profile of the document "Vision for W3C" from its w3c-state element; Please make sure the `<p id="w3c-state">` is in a valid format:

`<p id="w3c-state">W3C @@type of the document@@ DD Month YYYY</p>`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 18, 2024, 1:02 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL]([object Object])

```
Error running preprocessor, returned code: 2.
FATAL ERROR: PROGRAMMING ERROR: Group 'W3C/AB' has type 'none', but none of the W3C Statuses are associated with that type.
Your document appears to use tabs to indent, but line 206 starts with spaces.
Your document appears to use tabs to indent, but line 207 starts with spaces.
Your document appears to use tabs to indent, but line 208 starts with spaces.
Your document appears to use tabs to indent, but line 209 starts with spaces.
Your document appears to use tabs to indent, but line 211 starts with spaces.
Your document appears to use tabs to indent, but line 212 starts with spaces.
Your document appears to use tabs to indent, but line 213 starts with spaces.
Your document appears to use tabs to indent, but line 214 starts with spaces.
Your document appears to use tabs to indent, but line 216 starts with spaces.
Your document appears to use tabs to indent, but line 217 starts with spaces.
Your document appears to use tabs to indent, but line 219 starts with spaces.
Your document appears to use tabs to indent, but line 220 starts with spaces.
Your document appears to use tabs to indent, but line 221 starts with spaces.
Your document appears to use tabs to indent, but line 222 starts with spaces.
Your document appears to use tabs to indent, but line 223 starts with spaces.
Your document appears to use tabs to indent, but line 225 starts with spaces.
Your document appears to use tabs to indent, but line 226 starts with spaces.
Your document appears to use tabs to indent, but line 228 starts with spaces.
Your document appears to use tabs to indent, but line 229 starts with spaces.
WARNING: Multiple elements have the same ID 'w3c-state'.
Deduping, but this ID may not be stable across revisions.
 ✘  Did not generate, due to errors exceeding the allowed error level.
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/AB-public%23201.)._
</details>
