### PR TITLE
Use "wide and deep" instead of "broad and horizontal".

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -143,15 +143,17 @@ Markup Shorthands: markdown yes
 		we also strive to broaden diversity and inclusion for our own participants.
 	<li id=review>
 		**Thorough Review**:
-		We ensure the technical standards of the Web use broad and 
-		consistent horizontal review to ensure fundamental attributes such as
+		We ensure the technical standards of the Web
+		embody fundamental attributes such as
 		accessibility, 
 		internationalization,
 		sustainability,
 		privacy,
 		security,
 		technical soundness,
-		and architectural integrity.
+		and architectural integrity
+		through consistent deep and wide review.
+
 	<li id=consensus>
 		**Consensus**: We use principled, community-wide consensus-building
 		as the basis for building standards.

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -152,7 +152,7 @@ Markup Shorthands: markdown yes
 		security,
 		technical soundness,
 		and architectural integrity
-		through consistent deep and wide review.
+		through deep technical analysis and consistent wide and horizontal review.
 
 	<li id=consensus>
 		**Consensus**: We use principled, community-wide consensus-building


### PR DESCRIPTION
- Use the term "wide" rather than "broad", since that's the term we use elsewhere. (I like the way "broad" reads slightly better, but I think the consistency is more helpful to the community.)
- Add the term "deep", since we perform (and value) deep reviews of our specs as well as "wide" reviews: doing both is a key aspect of our ability to do "thorough" review.
- Drop the jargon term "horizontal", which is merely a part of "wide review" that currently has an encoded procedure in our guidebook.
- Restructure the sentence to avoid using the word "ensure" twice.

Fixes https://github.com/w3c/AB-public/pull/229