### PR TITLE
Refactor stakeholders and diversity section

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -136,7 +136,7 @@ Markup Shorthands: markdown yes
 	<li id=diversity>
 		**Diversity**: 
 		In order to ensure W3C serves the needs of the entire Web community, 
-		inclusion of participants from a <a href="https://www.w3.org/policies/code-of-conduct/#dfn-diversity">diverse range</a> of identities, lived experiences, abilities, and perspectives is fundamental.
+		we will include participants from a <a href="https://www.w3.org/policies/code-of-conduct/#dfn-diversity">diverse range</a> of identities, lived experiences, abilities, and perspectives and make them feel welcome.
 	<li id=review>
 		**Thorough Review**:
 		We ensure the technical standards of the Web use broad and 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -126,21 +126,17 @@ Markup Shorthands: markdown yes
 		**User-first**: We prioritize the needs of users over other constituencies, including over those of W3C Members.
 	<li id=multi-stakeholder>
 		**Multi-stakeholder**: We intentionally involve stakeholders from end to end
-		in building the Web: developers, content creators, and end users. 
-		Our work will not be dominated by any person, company, or interest group.
-	<li id=diversity>
-		**Diversity**: We believe in diversity
-		and inclusion of participants from different
+		in building the Web: developers, content creators, and end users.
+		We include stakeholders across different
 		geographical locations,
-		cultures,
-		languages,
-		disabilities,
-		gender identities,
 		industries,
 		organizational sizes,
 		and more.
+		Our work will not be dominated by any person, company, or interest group.
+	<li id=diversity>
+		**Diversity**: 
 		In order to ensure W3C serves the needs of the entire Web community, 
-		we also strive to broaden diversity and inclusion for our own participants.
+		inclusion of participants from a <a href="https://www.w3.org/policies/code-of-conduct/#dfn-diversity">diverse range</a> of identities, lived experiences, abilities, and perspectives is fundamental.
 	<li id=review>
 		**Thorough Review**:
 		We ensure the technical standards of the Web use broad and 


### PR DESCRIPTION
This fixes #169.

This takes a similar approach to https://github.com/w3c/AB-public/pull/171, but with a much simpler approach that results in much clearer text. 

* the org size et al attributes are included as aspects of stake-holders, rather than having to split into a separate point.
* the aspects of diversity are only mentioned at a high level, and the list is left to a reference to the CoC.