### PR TITLE
Prioritize people over society, and revert limitations on safety #211

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -93,9 +93,9 @@ Markup Shorthands: markdown yes
 
 # W3C's Vision for the World Wide Web # {#vision-web}
 
-	* The Web is for <a href="https://www.w3.org/TR/ethical-web-principles/#allpeople">all people</a>.
-	* The Web is designed for the <a href="https://www.w3.org/TR/ethical-web-principles/#noharm">good of humanity</a>.
-	* The Web must be <a href="https://www.w3.org/TR/ethical-web-principles/#privacy">secure and respect people's privacy</a>.
+	* The Web is for <a href="https://www.w3.org/TR/ethical-web-principles/#allpeople">all humanity</a>.
+	* The Web is designed for the <a href="https://www.w3.org/TR/ethical-web-principles/#noharm">good of all people</a>.
+	* The Web must be <a href="https://www.w3.org/TR/ethical-web-principles/#privacy">safe to use</a>.
 	* There is <a href="https://www.w3.org/TR/ethical-web-principles/#oneweb">one interoperable world-wide Web</a>.
 
 # Vision for W3C # {#vision-org}


### PR DESCRIPTION
Follow-up to the conversation in https://github.com/w3c/AB-public/pull/244 and https://github.com/w3c/AB-public/pull/250#issuecomment-2712187639 relating to [issue 211](https://github.com/w3c/AB-public/issues/211#issuecomment-2712179290).

2. Changes "for the good of all humanity" to "for the good of all people" to avoid prioritizing the "good" of a collective over its individuals, which has inspired so much evil in the past and present. See [Florian's comment](https://github.com/w3c/AB-public/issues/211#issuecomment-2705369514)

3. Returns "be secure and respect people's privacy" to a stronger concept of safety for the users. See [review comment](https://github.com/w3c/AB-public/pull/250#pullrequestreview-2672448100)

1. Returns "for all people" to "for all humanity" (revert from PR#250), since cwilso agrees the original phrasing was more eloquent, and it is no longer awkward due to repetition in item 2.