### PR TITLE
add "Core" to scope section 3 more accurately

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -91,7 +91,7 @@ Markup Shorthands: markdown yes
 	people over profits, 
 	humanity over hate. 
 
-# W3C's Vision for the World Wide Web # {#vision-web}
+# W3C's Core Vision for the World Wide Web # {#vision-web}
 
 	* The Web is for <a href="https://www.w3.org/TR/ethical-web-principles/#allpeople">all people</a>.
 	* The Web is designed for the <a href="https://www.w3.org/TR/ethical-web-principles/#noharm">good of humanity</a>.


### PR DESCRIPTION
This one word addition ("W3C Core Vision for the World Wide Web" as a replacement for "W3C Vision for the World Wide Web") is an attempt to resolve the "blocker" part of issue #215, in particular this comment: https://github.com/w3c/AB-public/issues/215#issuecomment-2520257238.

This makes sense because it is not the intent of this first version of the Vision to fully define "World Wide Web". I believe this is an improvement in the precision of this heading.

The remaining aspects of of #215 will be addressed in the next version (without objection).