### PR TITLE
Add link to TAG in Acknowlegements

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -204,7 +204,7 @@ Markup Shorthands: markdown yes
 		notably Chris Wilson, David Singer, Mike Champion, Tantek Çelik,
 		Tzviya Siegman, Avneesh Singh, and the rest of the Advisory Board
 		and Vision Task Force members.
-	* This document builds on the basis of the Technical Architecture Group's
+	* This document builds on the basis of the <a href="https://www.w3.org/2001/tag/">W3C Technical Architecture Group's</a>
 		excellent [[ETHICAL-WEB-PRINCIPLES inline|Ethical Web Principles]].
 		It is not intended to supplant that work nor redefine it,
 		but fit into the same framework and promote many of the same goals.


### PR DESCRIPTION
Just linking to TAG - similar to AB - in the Acknowledgements section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/AB-public/pull/279.html" title="Last updated on Jul 28, 2025, 7:44 AM UTC (fe6ad3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/279/ab7da0f...csarven:fe6ad3d.html" title="Last updated on Jul 28, 2025, 7:44 AM UTC (fe6ad3d)">Diff</a>