### PR TITLE
change Acks notably to editors thank+recognize AB + feedback improved

### DIFF
--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -225,9 +225,9 @@ Markup Shorthands: markdown yes
 		Song Xu, 
 		Tantek Çelik, 
 		Tatsuya Igarashi, 
-		Wendy Reid (co-chair), 
+		Wendy Reid, 
 		Amy van der Hiel (staff contact), 
-		An Qi (Angel) Li (staff, co-chair), 
+		An Qi (Angel) Li (staff), 
 		Ralph Swick (staff contact); 
 		in addition the following individuals whose specific feedback also helped improve this document, in alphabetical order: 
 		Alan Stearns, 


### PR DESCRIPTION
This is an editor's rewrite of the "notably" acknowledgments to a more accurate editors thanking and recognizing of key contributors of the Vision's origin document, AB participants who explicitly supported the Vision, and specific feedback from individuals which improved this document. Minor edit to the adjacent line to link to the broader AB Vision wiki page rather than a fragment of only one year. This PR resolves issues #270 and #277.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/280.html" title="Last updated on Jul 28, 2025, 11:59 AM UTC (ca09314)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/280/ab7da0f...ca09314.html" title="Last updated on Jul 28, 2025, 11:59 AM UTC (ca09314)">Diff</a>