### PR TITLE
fix errant smartquotes

### DIFF
--- a/Vision/Overview.html
+++ b/Vision/Overview.html
@@ -694,7 +694,7 @@ on <a href="https://www.w3.org/wiki/AB/Vision">the AB wiki</a>.</p>
     <li data-md>
      <p>The editors would like to thank and recognize
 the additional key contributors who wrote large portions of the original 
-<a href="”https://github.com/WebStandardsFuture/Vision”">Web Standards Future draft for a new Vision for W3C</a> 
+<a href="https://github.com/WebStandardsFuture/Vision">Web Standards Future draft for a new Vision for W3C</a> 
 which was the basis for this document: David Singer and Mike Champion;
 the Advisory Board (<abbr>AB</abbr>) Vision Task Force (<abbr>VisionTF</abbr>) chairs 
 who facilitated and drove this effort at W3C, in order: 

--- a/Vision/Vision.bs
+++ b/Vision/Vision.bs
@@ -201,7 +201,7 @@ Markup Shorthands: markdown yes
 		on <a href="https://www.w3.org/wiki/AB/Vision">the AB wiki</a>.
 	* The editors would like to thank and recognize
 		the additional key contributors who wrote large portions of the original 
-		<a href=”https://github.com/WebStandardsFuture/Vision”>Web Standards Future draft for a new Vision for W3C</a> 
+		<a href="https://github.com/WebStandardsFuture/Vision">Web Standards Future draft for a new Vision for W3C</a> 
 		which was the basis for this document: David Singer and Mike Champion;
 		the Advisory Board (<abbr>AB</abbr>) Vision Task Force (<abbr>VisionTF</abbr>) chairs 
 		who facilitated and drove this effort at W3C, in order: 


### PR DESCRIPTION
fix errant smartquotes in both Overview.html and Vision.bs in sync with fixes to published version of Vision


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/pull/281.html" title="Last updated on Jul 29, 2025, 10:10 PM UTC (6050b3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/AB-public/281/46ee1ac...6050b3b.html" title="Last updated on Jul 29, 2025, 10:10 PM UTC (6050b3b)">Diff</a>