### PR TITLE
Add Respec version of Council Report template

### DIFF
--- a/council-templates/council-report-template-respec.html
+++ b/council-templates/council-report-template-respec.html
@@ -144,7 +144,7 @@
         </section>
 
         <section id="minority" class="appendix">
-            <p>Appendix B: Minority Report</p>
+            <h2>Appendix B: Minority Report</h2>
 
             <blockquote>
                 <p>In the case of non-unanimous decisions, members of a W3C Council who disagree with the decision may write a Minority Opinion explaining the reason for their disagreement.</p>


### PR DESCRIPTION
Created a respec template for council reports, for those that prefer to work in Respec. 

Note, the template is currently not functional due to missing configurations in Respec, so I've opened an issue in their repo to address the issues: https://github.com/speced/respec/issues/5036 