### PR TITLE
Add summary for Advisory Board meeting on Oct 16, 2025

### DIFF
--- a/meetings/2025/10-16-summary.md
+++ b/meetings/2025/10-16-summary.md
@@ -15,7 +15,7 @@ for the next step of AB Liaison program.
 
 ## Oct 21 AB-led member meeting agenda
 The AB proposed topics to be discussed including update on Age-Based Restrictions on Content Access Workshop, TPAC2025 breakout
-session promotion, and how to make the AB-led member more open to the members.
+session promotion, and how to make the AB-led member meetings more open to the members.
 
 ## AB 2026 Priorities Status review - Process Refactoring/Simplification
 Brent has sent emails to the group chairs about meeting the groups during TPAC, and some group chairs have responded. Next step is


### PR DESCRIPTION
Documented the summary of the Advisory Board meeting held on October 16, 2025, including attendance, discussions, and future agendas.