### PR TITLE
Add summary of Advisory Board meeting on 10-November-2025

### DIFF
--- a/meetings/2025/11-10-summary.md
+++ b/meetings/2025/11-10-summary.md
@@ -1,9 +1,11 @@
 # Advisory Board meeting at TPAC
 10 November 2025
 
-attending: Amy, Angel, Brent, Dan_Appelquist, DingWei, elena, Emma, gendler, Hidde, hober, Igarashi, Max, Ota
+Attending: Amy, Angel, Brent, Dan_Appelquist, DingWei, elena, Emma, gendler, Hidde, hober, Igarashi, Max, Ota
 
-regrets: AvneeshSingh
+Regrets: AvneeshSingh
+
+Full minutes: https://www.w3.org/2025/11/10-ab-minutes.html (member-only link)
 
 ## Process Project planning
 The AB reviewed its plans for to meet with Groups at the TPAC to ask for feedback on the Process. Group assignments were discussed with two AB members per group where possible. Framing from Brent's Questionnaire included: "frank feedback on the Process any pain points you as a group have experienced” and "how Process interactions have gone.” As well as taking notes (without attributed comments) in the meetings, the AB wanted to encourage Members to give feedback on an ongoing basis, in email, via GH, in person and at the monthly meetings. The AB also mentioned the "Tell Us What's Wrong with the Process” Breakout on Wednesday. Brent asked to have encouragement to give input to the AB included in the daily TPAC mails. The AB discussed other interesting breakouts and the Tuesday hackathon led by Elena.


### PR DESCRIPTION
Documented the summary of the Advisory Board meeting held on November 10, 2025, including attendance, discussions on project planning, member survey results, and work mode.