### PR TITLE
Update python so bikeshed can install

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Build and deploy to gh-pages
     if: ${{ github.repository == 'w3c/AB-public' && github.event_name == 'push' }}
     env:
@@ -14,35 +14,25 @@ jobs:
       GH_EVENT_NUMBER: ${{ github.event.number }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
-      - name: Setup python 3.12
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.12"
-          architecture: x64
+        uses: actions/checkout@v6
       - name: Install bikeshed
         run: |
-          pip install bikeshed
+          pipx install bikeshed
           bikeshed update
           echo Bikeshed is ready
       - name: invoke deploy.sh
         run: ./deploy.sh
         shell: bash
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Check that the Vision builds cleanly
     if: ${{ github.repository != 'w3c/AB-public' || github.event_name == 'pull_request' }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
-      - name: Setup python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-          architecture: x64
+        uses: actions/checkout@v6
       - name: Install bikeshed
         run: |
-          pip install bikeshed
+          pipx install bikeshed
           bikeshed update
           echo Bikeshed is ready
       - name: invoke compile.sh


### PR DESCRIPTION
I did this by updating to ubuntu-latest, which includes an acceptable version of Python. Then I removed the explicit setup-python step, since the built-in version is fine. I also switched to `pipx install` since new Ubuntu refuses to run global `pip install`s.

And I updated to actions/checkout v6 since v2 relies on a deprecated version of Node.