### PR TITLE
[human rights position statement] Various tweaks to improve readability.

### DIFF
--- a/position-statements/furthering-human-rights/human-rights.md
+++ b/position-statements/furthering-human-rights/human-rights.md
@@ -1,12 +1,12 @@
 <section id="abstract">
 
-There is a clear link between human rights and technical standards setting. In this position paper, we list examples of how the two map, point to existing W3C work in this area, and provide concrete proposals to further the alignment between the W3C's technical work and human rights.
+There is a clear link between human rights and technical standards setting. In this position paper, we list examples of how the two map, point to existing <abbr title="World Wide Web Consortium">W3C</abbr> work in this area, and provide concrete proposals to further the alignment between the <abbr>W3C</abbr>’s technical work and human rights.
 
 </section>
 
 <section id="sotd">
 		
-This document summarizes the Advisory Board’s current thinking, as of 28 July 2026. 
+This document summarizes the Advisory Board’s current thinking, as of <time datetime=2026-07-28>28 July 2026</time>. 
 
 </section>
 
@@ -14,16 +14,15 @@ This document summarizes the Advisory Board’s current thinking, as of 28 July 
 	
 ## Context	
 
-In October of 2025, the United Nations Office of High Commissioner of Human Rights ([UN HCHR](https://www.ohchr.org/en/ohchr_homepage) issued [Tech and Human Rights Study: Making technical standards work for humanity](https://www.ohchr.org/en/documents/tools-and-resources/tech-and-human-rights-study-making-technical-standards-work-humanity). This report was 2 years in the making, and progress on its development had previously been [reported](https://www.w3.org/2024/04/AC/talk/human-rights#talk) at the W3C Advisory Committee meeting in Hiroshima, in April of 2024. At that meeting, and in the final report, the UN HCHR cited structural work in the W3C, specifically the Ethical Web Principles and the Code of Conduct, as key enablers linking the development of technical standards to human rights goals. 
+In October of 2025, the Office of the United Nations High Commissioner for Human Rights (<a href=https://www.ohchr.org/en/ohchr_homepage><abbr title="Office of the High Commissioner for Human Rights">OHCHR</abbr></a> issued [Tech and Human Rights Study: Making technical standards work for humanity](https://www.ohchr.org/en/documents/tools-and-resources/tech-and-human-rights-study-making-technical-standards-work-humanity). This report was two years in the making, and progress on its development had previously been [reported](https://www.w3.org/2024/04/AC/talk/human-rights#talk) at <a href=https://www.w3.org/2024/04/AC/>the April 2024 <abbr>W3C</abbr> Advisory Committee meeting in Hiroshima</a>. At that meeting, and in the final report, the <abbr>OHCHR</abbr> cited structural work in the <abbr>W3C</abbr>, specifically the Ethical Web Principles and the Code of Conduct, as key enablers linking the development of technical standards to human rights goals. 
 
-The [Ethical Web Principles](https://www.w3.org/TR/ethical-web-principles/), developed by the Technical Architecture Group and subsequently elevated to the status of W3C Statement, states that one goal of the document is to put internationally recognized human rights at the core of the web platform. That wording was also quoted in UN HCHR’s final report. The [W3C Vision](https://www.w3.org/TR/w3c-vision/), developed by the Advisory Board and also subsequently elevated to W3C Statement status, echoes these sentiments by stating that “the web is for all humanity”, that it is designed for the “good of all people,” and that it must be “safe to use.”
+The [Ethical Web Principles](https://www.w3.org/TR/ethical-web-principles/), developed by the Technical Architecture Group and subsequently elevated to the status of <abbr>W3C</abbr> Statement, states that one goal of the document is to put internationally recognized human rights at the core of the web platform. That wording was also quoted in <abbr>OHCHR</abbr>’s final report. The <a href=https://www.w3.org/TR/w3c-vision/><abbr>W3C</abbr> Vision</a>, developed by the Advisory Board and also subsequently elevated to <abbr>W3C</abbr> Statement status, echoes these sentiments by stating that “the web is for all humanity”, that it is designed for the “good of all people,” and that it must be “safe to use.”
 
-W3C as an organization has a strong track record of aligning our work with ethical / human rights goals. Accessibility and internationalization are two long-standing areas where W3C has created a reputation in this space. More recently, there has been work on privacy with the publication as a W3C Statement of the [Privacy Principles](https://www.w3.org/TR/privacy-principles/) and the creation of the [Privacy Working Group](https://www.w3.org/groups/wg/privacy/). In some cases, W3C has addressed human rights issues after a technology was already deployed, for example mitigating privacy issues related to the use of the [Geolocation API](https://www.w3.org/TR/geolocation/) by requiring HTTPS. Work on [web sustainability](https://www.w3.org/groups/ig/sustainableweb/) and societal impacts are some other burgeoning examples. Also, W3C is a non-profit with a responsibility for public good.
+<abbr>W3C</abbr> as an organization has a strong track record of aligning our work with ethical / human rights goals. Accessibility and internationalization are two long-standing areas where <abbr>W3C</abbr> has created a reputation in this space. More recently, there has been work on privacy with the publication as a <abbr>W3C</abbr> Statement of the [Privacy Principles](https://www.w3.org/TR/privacy-principles/) and the creation of the [Privacy Working Group](https://www.w3.org/groups/wg/privacy/). In some cases, <abbr>W3C</abbr> has addressed human rights issues after a technology was already deployed, for example mitigating privacy issues related to the use of the <a href=https://www.w3.org/TR/geolocation/>Geolocation <abbr title="Application Programming Interface">API</abbr></a> by requiring <abbr title="Secure Hypertext Transfer Protocol">HTTPS</abbr>. Work on [web sustainability](https://www.w3.org/groups/ig/sustainableweb/) and societal impacts are some other burgeoning examples. Also, <abbr>W3C</abbr> is a non-profit with a responsibility to operate for the public good.
 
-As the UN reports details, many regulatory and policy initiatives are founded in human rights. It therefore follows that technical standards which are also aligned with human rights will lead to greater alignment with global regulation, leading to easier adoption of W3C standards.
+As the <abbr title="United Nations">UN</abbr> report details, many regulatory and policy initiatives are founded in human rights. It therefore follows that technical standards which are also aligned with human rights will lead to greater alignment with global regulation, leading to easier adoption of <abbr>W3C</abbr> standards.
 
 Overall, we need to normalize the linkage between technical standards and human rights and further integrate human rights into our culture and operations.
-
 
 </section>
 
@@ -31,13 +30,13 @@ Overall, we need to normalize the linkage between technical standards and human 
 
 ## Examples of Specific Human Rights Mappings
 
-The relationship between human rights and web standards is not only abstract. Many standards produced at W3C map directly to specific human rights as outlined in the [UN Declaration](https://www.ohchr.org/en/human-rights/universal-declaration/translations/english). 
+The relationship between human rights and web standards is not only abstract. Many standards produced at <abbr>W3C</abbr> map directly to specific human rights as outlined in the [Universal Declaration of Human Rights](https://www.ohchr.org/en/human-rights/universal-declaration/translations/english).
 
 Some examples of that mapping:
 
 * Article 3, “Everyone has the right to life, liberty and the security of person”, is related to security and identity.
 * Article 5, “no one shall be subjected to torture or to cruel, inhuman or degrading treatment or punishment”, and Article 12, “No one shall be subjected to arbitrary interference with his privacy, family, home or correspondence…”, are directly related to web privacy, which is addressed in the [Privacy Principles](https://www.w3.org/TR/privacy-principles/). Specifications in the area are being developed in the [Privacy Working Group](https://www.w3.org/groups/wg/privacy/).
-* Article 19, “Everyone has the right to freedom of opinion and expression” is related to web privacy (“holding opinions without interference”), to the “one web” principle (“receive and impart information … regardless of frontiers”), to [accessibility of authoring](https://www.w3.org/TR/ATAG20/), and to open protocols to publish on the web ([HTML](https://www.w3.org/TR/html/), HTTP, [ActivityPub](https://www.w3.org/TR/activitypub/)). While not all of these specifications are developed at W3C, W3C can still play a role in raising human rights requirements.
+* Article 19, “Everyone has the right to freedom of opinion and expression” is related to web privacy (“holding opinions without interference”), to the “one web” principle (“receive and impart information … regardless of frontiers”), to [accessibility of authoring](https://www.w3.org/TR/ATAG20/), and to open protocols to publish on the web (<a href=https://www.w3.org/TR/html/><abbr title="Hypertext Markup Language">HTML</abbr></a>, <abbr title="Hypertext Transfer Protocol">HTTP</abbr>, [ActivityPub](https://www.w3.org/TR/activitypub/)). While not all of these specifications are developed at <abbr>W3C</abbr>, <abbr>W3C</abbr> can still play a role in raising human rights requirements.
 * Article 20, “Everyone has the right to freedom of peaceful assembly and association.”, is related to web privacy since lack of privacy (surveillance) can have a chilling effect on association.
 * Article 21, “Everyone has the right to take part in the government…”, is related to accessibility and internationalization, as many interactions between citizens and governments are mediated via the web.
 
@@ -47,32 +46,32 @@ Some examples of that mapping:
 
 ## Proposed Actions
 
-The following are concrete proposals for additional structural changes for the W3C that could help to further the goal of aligning the technical work program of W3C with the furtherance of Human Rights.
+The following are concrete proposals for additional structural changes for the <abbr>W3C</abbr> that could help to further the goal of aligning the technical work program of <abbr>W3C</abbr> with the furtherance of human rights.
 
 ### Participation Program for Civil Society Groups
 
-We need to encourage participation of more civil society groups, for example by lowering barriers to membership for NGOs that are working towards public good. This could also include allocating funding for participants of such groups to attend Working Group meetings or TPAC. We propose exploring this topic jointly between the AB and the Team to come up with a set of concrete proposals.
+We need to encourage the participation of more civil society groups, for example by lowering barriers to membership for <abbr title="Non-Governmental Organizations">NGOs</abbr> that are working towards the public good. This could also include allocating funding for participants of such groups to attend Working Group meetings or <abbr title="Technical Plenary and Advisory Committee">TPAC</abbr>. We propose exploring this topic jointly between the <abbr title="Advisory Board">AB</abbr> and the Team to come up with a set of concrete proposals.
 
 ### Threats and Harms Community Group
 
-It may be appropriate to create a Threats and Harms Community Group, with an explicit charter to develop documentation around threats and harms related to Human Rights issues. For example: human rights threat modelling, and principles, checklists, or questionnaires that could become part of wide review. A Community Group would have the advantage of open participation and at no cost. This group should have participation from civil society groups.
+It may be appropriate to create a Threats and Harms Community Group, with an explicit charter to develop documentation around threats and harms related to human rights issues. For example: human rights threat modelling, and principles, checklists, or questionnaires that could become part of wide review. A Community Group would have the advantage of open participation at no cost. This group should have participation from civil society groups.
 
 ### Human Rights / Societal Impact / Ethical Review Process
 
-The [wide review process](https://www.w3.org/policies/process/#wide-review) process of W3C should be expanded by adding more reviews which directly impact the alignment with the human rights. This should make use of existing consensus documents such as those coming out of TAG and other groups, expanding beyond privacy, accessibility, and internationalization into areas such as [societal impact](https://www.w3.org/TR/societal-impact-questionnaire/).
+The [wide review process](https://www.w3.org/policies/process/#wide-review) of <abbr>W3C</abbr> should be expanded by adding more reviews which directly impact alignment with human rights. This should make use of existing consensus documents such as those coming out of the <abbr title="Technical Architecture Group">TAG</abbr> and other groups, expanding beyond privacy, accessibility, and internationalization into areas such as [societal impact](https://www.w3.org/TR/societal-impact-questionnaire/).
 
-### Program to Increase Diversity of Participation (and Inclusion) in W3C
+### Program to Increase Diversity of Participation (and Inclusion) in <abbr>W3C</abbr>
 
-A structured program that could include fee waivers, funded fellowships, upskilling initiatives, mentorship, training, and institutional partnerships. The goal is to get more stakeholders involved at all stages, including during charter creation, and to empower groups to address social harms (see “Overcoming barriers to participation and inclusion” in the UN report).
+A structured program that could include fee waivers, funded fellowships, upskilling initiatives, mentorship, training, and institutional partnerships. The goal is to get more stakeholders involved at all stages, including during charter creation, and to empower groups to address social harms (see “Overcoming barriers to participation and inclusion” in the <abbr>UN</abbr> report).
 
-### Periodic and Transparent Human Rights in W3C Standards Reporting
+### Periodic and Transparent Human Rights in <abbr>W3C</abbr> Standards Reporting
 
-W3C should issue a public human rights transparency report every year that outlines technical reports, documents, and programs that can help advance human rights. It should also state the W3C’s plans for new documents and programs. In doing so, we should emphasize that the focus is on the standards we produce, and the way we do our work. This report should also include information on already-deployed web technologies.
+<abbr>W3C</abbr> should issue a public human rights transparency report every year that outlines technical reports, documents, and programs that can help advance human rights. It should also state the <abbr>W3C</abbr>’s plans for new documents and programs. In doing so, we should emphasize that the focus is on the standards we produce, and the way we do our work. This report should also include information on already-deployed web technologies.
 
 </section>
 <section class="appendix">
 
 ## Acknowledgements
-The AB would like to thank Simone Onofri for his input and feedback on early drafts of this paper.
+The <abbr>AB</abbr> would like to thank Simone Onofri for his input and feedback on early drafts of this paper.
 
 </section>


### PR DESCRIPTION
A bunch of (hopefully non-controversial) tweaks to improve the readability of the document:

* fixed the use of a "dumb quote" instead of a "smart quote"
* Use HTML's `abbr` and `time` elements where appropriate. (For `abbr`, the PR only provides `title=""` at first use, to not annoy screen reader users.)
* Use the correct name and abbreviation for OHCHR throughout, and use UDHR's proper name where it's mentioned.
* Spelled out a number instead of using a numeral for readability.
* Link to the mentioned AC meeting in Hiroshima.
* Fix various grammar nits (added or removed some articles, dropped duplicate words in a couple of places, fixed capitalization, that kind of thing).

Sorry for blending multiple kinds of changes into one PR.